### PR TITLE
Improve marketing text

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -5,35 +5,50 @@ import * as icons from "react-feather";
 
 export default Layout;
 
+<!-- You have to leave a blank line after <FeaturesItem> and the feature's text,
+     as well as between the text and </FeaturesItem>. Otherwise, you will
+     disable hyphenation and smart punctuation. Also, the text must not indented. -->
+
 <Features>
-  <FeaturesItem icon={<icons.Cpu />} title="Resource-efficient">
-    Deal with more requests with less resources compared to traditional stacks and frameworks based on blocking I/O.
-    Vert.x is a great fit for all kinds of execution environments, including constrained environments like virtual machines and containers.
-    Don't waste resources, increase deployment density and save money!
-  </FeaturesItem>
-  
-  <FeaturesItem icon={<icons.Sliders />} title="Concurrent and asynchronous">
-    People told you that asynchronous programming is too hard for you.
-    We strive to make programming with Vert.x an approachable experience, without sacrifying correctness and performance.
-    With Vert.x you can pick the model that works best for the task at hand: callbacks, promises and futures, reactive extensions, and (Kotlin) coroutines.
-  </FeaturesItem>
-  
-  <FeaturesItem icon={<icons.Feather />} title="Flexible">
-    Vert.x is a toolkit, not a framework, so it is naturally very composable and embeddable.
-    We have no strong opinion on what your application structure should be like.
-    Select the modules and clients that you need and compose them as you craft your application: Vert.x will always adapt and scale depending on your needs.
-  </FeaturesItem>
+<FeaturesItem icon={<icons.Cpu />} title="Resource-efficient">
 
-  <FeaturesItem icon={<icons.Send />} title="Vert.x is fun">
-    Forget complexity and costly abstractions: with Vert.x what you write is actually what you get to execute!
-    Get back to simple designs, forget some of the established "best practices", and enjoy writing code that is comprehensible and that won't let you down in the future.
-    We also have a friendly community, so you can learn from people who have used Vert.x in very diverse settings.
-  </FeaturesItem>
+Handle more requests with less resources compared to traditional stacks and frameworks based on blocking I/O.
+Vert.x is a great fit for all kinds of execution environments, including constrained environments like virtual machines and containers.
 
-  <FeaturesItem icon={<icons.Umbrella />} title="Ecosystem">
-    Web APIs, databases, messaging, event streams, cloud, registries, security... you name it.
-    Vert.x has you covered with a comprehensive end-to-end reactive clients stack for the major technologies used in modern applications.
-    And if you can't find what you are looking for there is a very strong chance that someone else has done it in the wider Vert.x opensource ecosystem.
-    Vert.x is a safe investment for your technology stack.
-  </FeaturesItem>
+Don't waste resources, increase deployment density and save money!
+
+</FeaturesItem>
+<FeaturesItem icon={<icons.Sliders />} title="Concurrent and asynchronous">
+
+People told you asynchronous programming is too hard for you?
+We strive to make programming with Vert.x an approachable experience, without sacrifying correctness and performance.
+
+You pick the model that works best for the task at hand: callbacks, promises, futures, reactive extensions, and (Kotlin) coroutines.
+
+</FeaturesItem>
+<FeaturesItem icon={<icons.Feather />} title="Flexible">
+
+Vert.x is a toolkit, not a framework, so it is naturally very composable and embeddable.
+We have no strong opinion on what your application structure should be like.
+
+Select the modules and clients you need and compose them as you craft your application. Vert.x will always adapt and scale depending on your needs.
+
+</FeaturesItem>
+<FeaturesItem icon={<icons.Send />} title="Vert.x is fun">
+
+Forget complexity and costly abstractions. With Vert.x, what you write is actually what you get to execute!
+Get back to simple designs, forget some of the established "best practices", and enjoy writing code that is comprehensible and that won't let you down in the future.
+
+We also have a friendly community, so you can learn from people who have used Vert.x in very diverse settings.
+
+</FeaturesItem>
+<FeaturesItem icon={<icons.Umbrella />} title="Ecosystem">
+
+Web APIs, databases, messaging, event streams, cloud, registries, security... you name it.
+Vert.x has you covered with a comprehensive end-to-end reactive clients stack for modern applications.
+
+And if you can't find what you are looking for, there is a very strong chance that someone else has done it in the wider Vert.x open-source ecosystem.
+Vert.x is a safe investment for your technology stack.
+
+</FeaturesItem>
 </Features>


### PR DESCRIPTION
@jponge Thanks for the marketing text on the front page. I made some adjustments to improve legibility. The text blocks are now balanced and consists of two paragraphs each (I had to slightly shorten the text a bit here and there). I also added some missing commas and re-enabled hyphenation and smart punctuation. I hope this meets with your approval.