### PR TITLE
v3 to v4 page draft

### DIFF
--- a/pages/from-vert-x-3-to-vert-x-4.mdx
+++ b/pages/from-vert-x-3-to-vert-x-4.mdx
@@ -13,7 +13,7 @@ users will feel at home with Vert.x 4 .
 
 ## Migration
 
-We have decided a few strategies to help the transition from Vert.x 3 to Vert.x 4.
+Vert.x 4 has been developed with migration from Vert.x 3 in mind.
 
 When possible Vert.x 4 API have been made available in Vert.x 3 with a deprecation of the old API, giving
 the opportunity to improve Vert.x 3 application with a better API while allowing application to be ready for a Vert.x 4
@@ -22,12 +22,14 @@ migration.
 We provide a clear and documented [migration path](https://github.com/vert-x3/vertx-4-migration-guide/) from Vert.x 3.9
 to Vert.x 4.0.
 
+Each sample in [Vert.x in Action](https://www.manning.com/books/vertx-in-action) with Vert.x 3.9 or Vert.x 4.
+
 ## Vert.x 3 support
 
 Vert.x 3 will continue to get bug fix releases officially until January 2023.
 
-Vert.x is an open source project of the Eclipse Foundation, granting the community the opportunity to contribute bug
-fixes beyond that deadline.
+Vert.x is an open source project of the Eclipse Foundation, granting the community the opportunity to contribute
+fixes beyond that deadline and possibly extend the support.
 
 
 

--- a/pages/from-vert-x-3-to-vert-x-4.mdx
+++ b/pages/from-vert-x-3-to-vert-x-4.mdx
@@ -1,0 +1,35 @@
+import Layout from "../components/layouts/Intro"
+import Link from "next/link"
+export default Layout
+
+export const meta = {
+  title: "From Vert.x 3 to Vert.x 4"
+}
+
+# From Vert.x 3 to Vert.x 4
+
+Vert.x 4 extends the Vert.x 3 line with a set of new features while providing the same Vert.x 3 experience: Vert.3
+users will feel at home with Vert.x 4 .
+
+## Migration
+
+We have decided a few strategies to help the transition from Vert.x 3 to Vert.x 4.
+
+When possible Vert.x 4 API have been made available in Vert.x 3 with a deprecation of the old API, giving
+the opportunity to improve Vert.x 3 application with a better API while allowing application to be ready for a Vert.x 4
+migration.
+
+We provide a clear and documented [migration path](https://github.com/vert-x3/vertx-4-migration-guide/) from Vert.x 3.9
+to Vert.x 4.0.
+
+## Vert.x 3 support
+
+Vert.x 3 will continue to get bug fix releases officially until January 2023.
+
+Vert.x is an open source project of the Eclipse Foundation, granting the community the opportunity to contribute bug
+fixes beyond that deadline.
+
+
+
+
+


### PR DESCRIPTION
Draft of the v3 to v4 page.

Goals of this page, is to clarify a few things to the community:

- users don't have to be worried by Vert.x 4 removing Vert.x 3
- migration to Vert.x 4 is supported with a clear migration path
- Vert.x 3 end of life and open to community contributions



