### PR TITLE
Add missing language bindings for Groovy and Kotlin

### DIFF
--- a/components/layouts/DocsIndex.scss
+++ b/components/layouts/DocsIndex.scss
@@ -148,6 +148,10 @@
     svg {
       stroke: $gray-700;
       margin-right: $spacer / 2;
+
+      &.no-stroke {
+        stroke: none;
+      }
     }
   }
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -21,7 +21,7 @@ ext {
     "3.8.4",
 
     // latest version
-    "4.0.0"
+    "4.0.1-SNAPSHOT"
   ]
 }
 

--- a/docs/metadata/4.0.0.jsx
+++ b/docs/metadata/4.0.0.jsx
@@ -110,7 +110,7 @@ docs.entries.push({
 docs.entries.push({
   id: "vertx-lang-groovy",
   name: "Vert.x for Groovy",
-  description: `Groovy bindings and helpers for Vert.x.`,
+  description: "Groovy bindings and helpers for Vert.x.",
   category: "groovy",
   href: "/vertx-core/groovy/",
   repository: "https://github.com/vert-x3/vertx-lang-groovy",
@@ -120,12 +120,13 @@ docs.entries.push({
 docs.entries.push({
   id: "vertx-lang-kotlin",
   name: "Vert.x for Kotlin",
-  description: `Kotlin bindings and helpers for Vert.x.`,
+  description: "Kotlin bindings and helpers for Vert.x.",
   category: "kotlin",
   href: "/vertx-core/kotlin/",
   repository: "https://github.com/vert-x3/vertx-lang-kotlin",
   edit: "https://github.com/vert-x3/vertx-lang-kotlin/tree/master/vertx-lang-kotlin/src/main/asciidoc"
 })
+
 docs.entries.push({
     id: "vertx-lang-kotlin-coroutines",
     name: "Kotlin coroutines",

--- a/docs/metadata/4.0.0.jsx
+++ b/docs/metadata/4.0.0.jsx
@@ -1,4 +1,5 @@
 import { Book, Monitor } from "react-feather"
+import { Groovy, Kotlin } from "@icons-pack/react-simple-icons"
 import oldDocs from "./3.9.4"
 import { clone, find, findCategory, insert, move, remove } from "./helpers"
 
@@ -19,12 +20,12 @@ docs.categories = [
   {
     id: "kotlin",
     name: "Kotlin",
-    icon: <Book />
+    icon: <Kotlin className="no-stroke" />
   },
   {
     id: "groovy",
     name: "Groovy",
-    icon: <Book />
+    icon: <Groovy className="no-stroke" />
   },
   findCategory(docs, "authentication-and-authorization"),
   findCategory(docs, "databases"),

--- a/docs/metadata/4.0.0.jsx
+++ b/docs/metadata/4.0.0.jsx
@@ -16,6 +16,16 @@ docs.categories = [
     name: "Standards",
     icon: <Book />
   },
+  {
+    id: "kotlin",
+    name: "Kotlin",
+    icon: <Book />
+  },
+  {
+    id: "groovy",
+    name: "Groovy",
+    icon: <Book />
+  },
   findCategory(docs, "authentication-and-authorization"),
   findCategory(docs, "databases"),
   findCategory(docs, "messaging"),
@@ -95,6 +105,38 @@ docs.entries.push({
   repository: "https://github.com/eclipse-vertx/vertx-json-schema",
   edit: "https://github.com/eclipse-vertx/vertx-json-schema/tree/master/src/main/asciidoc",
   label: "Technical Preview"
+})
+
+docs.entries.push({
+  id: "vertx-lang-groovy",
+  name: "Vert.x for Groovy",
+  description: `Groovy bindings and helpers for Vert.x.`,
+  category: "groovy",
+  href: "/vertx-core/groovy/",
+  repository: "https://github.com/vert-x3/vertx-lang-groovy",
+  edit: "https://github.com/vert-x3/vertx-lang-groovy/tree/master/src/main/asciidoc"
+})
+
+docs.entries.push({
+  id: "vertx-lang-kotlin",
+  name: "Vert.x for Kotlin",
+  description: `Kotlin bindings and helpers for Vert.x.`,
+  category: "kotlin",
+  href: "/vertx-core/kotlin/",
+  repository: "https://github.com/vert-x3/vertx-lang-kotlin",
+  edit: "https://github.com/vert-x3/vertx-lang-kotlin/tree/master/vertx-lang-kotlin/src/main/asciidoc"
+})
+docs.entries.push({
+    id: "vertx-lang-kotlin-coroutines",
+    name: "Kotlin coroutines",
+    description: `Kotlin coroutines for Vert.x, gives you super powers such as
+      async/await or Go-like channels. This enables you to write your verticle
+      code in a familiar sequential style.`,
+    category: "kotlin",
+    href: "/vertx-lang-kotlin-coroutines/kotlin/",
+    repository: "https://github.com/vert-x3/vertx-lang-kotlin",
+    edit: "https://github.com/vert-x3/vertx-lang-kotlin/tree/master/vertx-lang-kotlin/src/main/asciidoc",
+    examples: "https://github.com/vert-x3/vertx-examples/tree/3.x/kotlin-examples/coroutines"
 })
 
 insert(docs, "vertx-auth-mongo",


### PR DESCRIPTION
The current web-site is missing Groovy and Kotlin documentation (not the translated one).

These documentations were misplaced in the docs zip file and this has been fixed upstream (hence there is a temporary upgrade to use 4.0.1-SNAPSHOT docs zip in this PR). What changes in the docs zip:

- Vertx. for Groovy docs is available in vertx-core/groovy folder (to maintain compatibility with existing URLs)
- Vertx. for Kotlin docs is available in vertx-core/kotlin folder (to maintain compatibility with existing URLs)


In addition the docs metadata is updated with a Groovy and Kotlin categories

- the Groovy category gets a link to vertx-core/groovy
- the Kotlin category gets a link to vertx-core/kotlin and the coroutines documentation that was removed by mistake

What is missing:
- we need an icon for Groovy
- we need an icon for Kotlin



