### PR TITLE
Add a security.txt and link to the footer

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -53,6 +53,7 @@ const Footer = () => {
               <li><Link href="/blog/"><a>Blog</a></Link></li>
               <li><Link href="/community/"><a>Community</a></Link></li>
               <li><a href="https://github.com/eclipse-vertx/vert.x">GitHub</a></li>
+              <li><a href="/.well-known/security.txt">security.txt</a></li>
             </ul>
           </div>
           <div className="footer-nav-list">

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,9 @@
+# Reporting a vulnerability
+#
+# The Eclipse Vert.x team provides a single point of contact for the reporting
+# of security vulnerabilities in any of the open source modules and coordinates
+# the process of investigating any reported vulnerabilities.
+
+Contact: mailto:vertx-enquiries@googlegroups.com
+Encryption: openpgp4fpr:33F0D7AE129514007CDF67DE9F9358A769793D09
+Expires: 2022-12-31T23:59:59z


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

This PR adds a link to allow security reports to be visible from the footer or using the RFC:

https://datatracker.ietf.org/doc/html/draft-foudil-securitytxt-12

