### PR TITLE
fetch contributions also from the new eclipse-vertx org

### DIFF
--- a/pages/community.jsx
+++ b/pages/community.jsx
@@ -165,7 +165,7 @@ async function fetchContributors(octokit) {
   }]
 
   console.log("Fetching repositories ...")
-  let fetchedRepos = await pMap(["vert-x", "vert-x3", "vertx-web-site"], org =>
+  let fetchedRepos = await pMap(["vert-x", "vert-x3", "vertx-web-site", "eclipse-vertx"], org =>
     octokit.paginate(octokit.repos.listForOrg, { org }), { concurrency: MAX_CONCURRENCY })
   for (let fetchedRepo of fetchedRepos) {
     repos = repos.concat(fetchedRepo)


### PR DESCRIPTION
A lot of contributions happen also in the new eclipse-vertx org. This change will consider the new org when fetching contributions.