### PR TITLE
gRPC Server can't be used as a Web handler

### DIFF
--- a/blog/2022-05-12-whats-new-in-vert-x-4-3.mdx
+++ b/blog/2022-05-12-whats-new-in-vert-x-4-3.mdx
@@ -136,7 +136,7 @@ GrpcServer grpcServer = GrpcServer.server(vertx);
 GrpcServiceBridge serverStub = GrpcServiceBridge.bridge(service);
 serverStub.bind(grpcServer);
 
-router.consumes("application/grpc").handler(grpcServer);
+router.consumes("application/grpc").handler(rc -> grpcServer.handle(rc.request()));
 ```
 
 ### Extra HTTP compression algorithms


### PR DESCRIPTION
Related to https://github.com/eclipse-vertx/vertx-grpc/issues/84