### PR TITLE
Fix links in What's new in Vert.x 5 link

### DIFF
--- a/blog/2024-12-11-whats-new-in-vert-x-5.mdx
+++ b/blog/2024-12-11-whats-new-in-vert-x-5.mdx
@@ -95,14 +95,14 @@ https://vertx.io/docs/vertx-grpc/java/#vertx-grpc-protoc-plugin
 
 ### gRPC deadlines
 
-Vert.x gRPC handles timeout and deadlines in both [client](https://vertx.io/docs/5.0.0.CR5/vertx-grpc/java/#_timeout_and_deadlines_2)
+Vert.x gRPC handles timeout and deadlines in both [client](https://vertx.io/docs/5.0.0/vertx-grpc/java/#_timeout_and_deadlines_2)
 and [server](https://vertx.io/docs/5.0.0.5/vertx-grpc/java/#_timeout_and_deadlines)
 
 Here is a simple [example](https://github.com/vert-x3/vertx-examples/tree/5.x/grpc-examples#timeout-and-deadlines).
 
 ### Reflection service
 
-Support for the [gRPC reflection service](https://vertx.io/docs/5.0.0.CR7/vertx-grpc/java/#_grpc_reflection_apis) can be added to your Vert.x gRPC Server, which can be used by tools like
+Support for the [gRPC reflection service](https://vertx.io/docs/5.0.0/vertx-grpc/java/#_grpc_reflection_apis) can be added to your Vert.x gRPC Server, which can be used by tools like
 [gRPCurl](https://github.com/fullstorydev/grpcurl)
 
 ### Health service
@@ -134,7 +134,7 @@ as well as a gRPC client [example](https://github.com/vert-x3/vertx-examples/tre
 
 ## Service resolver
 
-[Vert.x Service Resolver](https://vertx.io/docs/5.0.0.CR5/vertx-service-resolver/java/) is a new addition to
+[Vert.x Service Resolver](https://vertx.io/docs/5.0.0/vertx-service-resolver/java/) is a new addition to
 the Vert.x stack aiming to provide dynamic address resolution for clients, it extends the vertx core client side load
 balancing to a new set of service resolvers.
 
@@ -145,7 +145,7 @@ You can find here a few [examples](https://github.com/vert-x3/vertx-examples/tre
 
 ## HTTP proxy
 
-The interception [side](https://vertx.io/docs/5.0.0.CR5/vertx-http-proxy/java/#_proxy_interception) of our HTTP proxy
+The interception [side](https://vertx.io/docs/5.0.0/vertx-http-proxy/java/#_proxy_interception) of our HTTP proxy
 has been improved with out-of-the-box transformations and interceptor in WebSocket upgrades.
 
 In addition, the caching part gets a proper caching Service Provider Interface (SPI) as well as extended support for
@@ -158,11 +158,11 @@ You can find here a few [examples](https://github.com/vert-x3/vertx-examples/tre
 ### Unix domain sockets
 
 Unix domain sockets have historically supported exclusively by native transports, they are now
-[available](https://vertx.io/docs/5.0.0.CR5/vertx-core/java/#_listening_to_unix_domain_sockets) for JDK 16 or greater.
+[available](https://vertx.io/docs/5.0.0/vertx-core/java/#_listening_to_unix_domain_sockets) for JDK 16 or greater.
 
 ### Connect options
 
-TCP and HTTP clients have finer grained [Connect](https://vertx.io/docs/5.0.0.CR5/apidocs/io/vertx/core/net/ConnectOptions.html)
+TCP and HTTP clients have finer grained [Connect](https://vertx.io/docs/5.0.0/apidocs/io/vertx/core/net/ConnectOptions.html)
 capabilities, providing per connection SSL and proxy options. Previously such configuration was only possible client wide.
 
 ### Un-pooled HTTP connection
@@ -171,7 +171,7 @@ Default interactions with an HTTP servers involves providing a request object an
 connection to the actual server and then pool it for subsequent uses.
 
 Sometimes it is desirable to manage such connections instead of reusing pooled connections, for this use case the Vert.x
-HTTP client provides [un-pooled](https://vertx.io/docs/5.0.0.CR2/vertx-core/java/#_un_pooled_client_connections) connections.
+HTTP client provides [un-pooled](https://vertx.io/docs/5.0.0/vertx-core/java/#_un_pooled_client_connections) connections.
 
 You can find here an [example](https://github.com/vert-x3/vertx-examples/blob/5.x/core-examples/README.adoc#un-managed-client-connection)
 
@@ -181,7 +181,7 @@ Our integration of Micrometer Metrics overhead has been reduced, you can learn m
 
 ### TCP shutdown
 
-HTTP server and client support graceful [shutdown](https://vertx.io/docs/5.0.0.CR2/vertx-core/java/#_tcp_graceful_shut_down).
+HTTP server and client support graceful [shutdown](https://vertx.io/docs/5.0.0/vertx-core/java/#_tcp_graceful_shut_down).
 
 You can shut down a server or a client.
 
@@ -197,7 +197,7 @@ You can find here an [example](https://github.com/vert-x3/vertx-examples/tree/5.
 
 ### Application Launcher
 
-Application [launcher](https://vertx.io/docs/5.0.0.CR5/vertx-launcher-application/java/) is a new tool which addresses the
+Application [launcher](https://vertx.io/docs/5.0.0/vertx-launcher-application/java/) is a new tool which addresses the
 concern of launching a Vert.x application packaged as a far jar. It replaces the Vert.x 4 `io.vertx.core.Launcher`.
 
 ## Sunsets and removals


### PR DESCRIPTION
Some still point to CR releases docs